### PR TITLE
Adicionando @JsonIgnoreProperties. 

### DIFF
--- a/src/main/java/BankApplication/account/controller/client/controller/ClientController.java
+++ b/src/main/java/BankApplication/account/controller/client/controller/ClientController.java
@@ -1,10 +1,10 @@
-package BankApplication.client.controller;
+package BankApplication.account.controller.client.controller;
 
 
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import BankApplication.model.Client;
-import BankApplication.client.request.ClientRequest;
+import BankApplication.account.controller.client.request.ClientRequest;
 
-import BankApplication.client.service.ClientServiceImpl;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import jakarta.transaction.Transactional;

--- a/src/main/java/BankApplication/account/controller/client/exceptions/ClientDoesntExistException.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/ClientDoesntExistException.java
@@ -1,4 +1,4 @@
-package BankApplication.client.exceptions;
+package BankApplication.account.controller.client.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/BankApplication/account/controller/client/exceptions/CpfAlreadyExistsException.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/CpfAlreadyExistsException.java
@@ -1,4 +1,4 @@
-package BankApplication.client.exceptions;
+package BankApplication.account.controller.client.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/BankApplication/account/controller/client/exceptions/details/ClientDoesntExistExceptionDetails.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/details/ClientDoesntExistExceptionDetails.java
@@ -1,4 +1,4 @@
-package BankApplication.client.exceptions.details;
+package BankApplication.account.controller.client.exceptions.details;
 
 public class ClientDoesntExistExceptionDetails {
 

--- a/src/main/java/BankApplication/account/controller/client/exceptions/details/CpfRegistredExceptionDetails.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/details/CpfRegistredExceptionDetails.java
@@ -1,4 +1,4 @@
-package BankApplication.client.exceptions.details;
+package BankApplication.account.controller.client.exceptions.details;
 
 public class CpfRegistredExceptionDetails {
 

--- a/src/main/java/BankApplication/account/controller/client/exceptions/handler/ClientDoesntExistExceptionHandler.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/handler/ClientDoesntExistExceptionHandler.java
@@ -1,7 +1,7 @@
-package BankApplication.client.exceptions.handler;
+package BankApplication.account.controller.client.exceptions.handler;
 
-import BankApplication.client.exceptions.ClientDoesntExistException;
-import BankApplication.client.exceptions.details.ClientDoesntExistExceptionDetails;
+import BankApplication.account.controller.client.exceptions.ClientDoesntExistException;
+import BankApplication.account.controller.client.exceptions.details.ClientDoesntExistExceptionDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;

--- a/src/main/java/BankApplication/account/controller/client/exceptions/handler/CpfAlreadyExistsExceptionHandler.java
+++ b/src/main/java/BankApplication/account/controller/client/exceptions/handler/CpfAlreadyExistsExceptionHandler.java
@@ -1,7 +1,7 @@
-package BankApplication.client.exceptions.handler;
+package BankApplication.account.controller.client.exceptions.handler;
 
-import BankApplication.client.exceptions.CpfAlreadyExistsException;
-import BankApplication.client.exceptions.details.CpfRegistredExceptionDetails;
+import BankApplication.account.controller.client.exceptions.CpfAlreadyExistsException;
+import BankApplication.account.controller.client.exceptions.details.CpfRegistredExceptionDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;

--- a/src/main/java/BankApplication/account/controller/client/repository/ClientRepository.java
+++ b/src/main/java/BankApplication/account/controller/client/repository/ClientRepository.java
@@ -1,4 +1,4 @@
-package BankApplication.client.repository;
+package BankApplication.account.controller.client.repository;
 
 import BankApplication.model.Client;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/BankApplication/account/controller/client/request/ClientRequest.java
+++ b/src/main/java/BankApplication/account/controller/client/request/ClientRequest.java
@@ -1,4 +1,4 @@
-package BankApplication.client.request;
+package BankApplication.account.controller.client.request;
 
 import BankApplication.model.Client;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/BankApplication/account/controller/client/response/ClientResponse.java
+++ b/src/main/java/BankApplication/account/controller/client/response/ClientResponse.java
@@ -1,4 +1,4 @@
-package BankApplication.client.response;
+package BankApplication.account.controller.client.response;
 public class ClientResponse {
     private final String name;
 

--- a/src/main/java/BankApplication/account/controller/client/service/ClientService.java
+++ b/src/main/java/BankApplication/account/controller/client/service/ClientService.java
@@ -1,4 +1,4 @@
-package BankApplication.client.service;
+package BankApplication.account.controller.client.service;
 
 import BankApplication.model.Client;
 

--- a/src/main/java/BankApplication/account/controller/client/service/ClientServiceImpl.java
+++ b/src/main/java/BankApplication/account/controller/client/service/ClientServiceImpl.java
@@ -1,12 +1,12 @@
-package BankApplication.client.service;
+package BankApplication.account.controller.client.service;
 
+import BankApplication.account.controller.client.exceptions.ClientDoesntExistException;
+import BankApplication.account.controller.client.exceptions.CpfAlreadyExistsException;
 import BankApplication.account.repository.AccountRepository;
-import BankApplication.client.exceptions.ClientDoesntExistException;
-import BankApplication.client.exceptions.CpfAlreadyExistsException;
 import BankApplication.model.Account;
 import BankApplication.model.Client;
-import BankApplication.client.repository.ClientRepository;
-import BankApplication.client.request.ClientRequest;
+import BankApplication.account.controller.client.repository.ClientRepository;
+import BankApplication.account.controller.client.request.ClientRequest;
 import jakarta.validation.Valid;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/BankApplication/account/service/AccountServiceImpl.java
+++ b/src/main/java/BankApplication/account/service/AccountServiceImpl.java
@@ -1,12 +1,12 @@
 package BankApplication.account.service;
 
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import BankApplication.account.exceptions.AccountAlreadyExistsException;
 import BankApplication.account.exceptions.AccountDoesntExistException;
 import BankApplication.model.Account;
 import BankApplication.model.Client;
 import BankApplication.account.repository.AccountRepository;
-import BankApplication.client.repository.ClientRepository;
+import BankApplication.account.controller.client.repository.ClientRepository;
 import BankApplication.account.request.AccountRequest;
 
 import jakarta.validation.Valid;

--- a/src/main/java/BankApplication/model/Account.java
+++ b/src/main/java/BankApplication/model/Account.java
@@ -1,5 +1,6 @@
 package BankApplication.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Pattern;
@@ -21,6 +22,7 @@ public class Account {
 
     @JoinColumn(name = "client_id", foreignKey = @ForeignKey)
     @OneToOne
+    @JsonIgnoreProperties({"id","cpf","createdData","postalCode","street"})
     private Client client;
 
     @OneToMany(targetEntity = Transaction.class, mappedBy = "account")

--- a/src/main/java/BankApplication/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/BankApplication/transaction/service/TransactionServiceImpl.java
@@ -3,7 +3,7 @@ package BankApplication.transaction.service;
 import BankApplication.account.exceptions.AccountAlreadyExistsException;
 import BankApplication.account.repository.AccountRepository;
 import BankApplication.account.service.AccountServiceImpl;
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import BankApplication.model.Account;
 import BankApplication.model.Transaction;
 import BankApplication.transaction.exception.ValueNotAcceptedException;

--- a/src/test/java/BankApplication/account/ControllerTests/AccountControllerTests.java
+++ b/src/test/java/BankApplication/account/ControllerTests/AccountControllerTests.java
@@ -7,9 +7,9 @@ import BankApplication.account.request.AccountRequest;
 import BankApplication.account.service.AccountServiceImpl;
 
 
-import BankApplication.client.repository.ClientRepository;
-import BankApplication.client.request.ClientRequest;
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.repository.ClientRepository;
+import BankApplication.account.controller.client.request.ClientRequest;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import BankApplication.model.Account;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -23,8 +23,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(AccountController.class)
@@ -67,24 +65,17 @@ public class AccountControllerTests {
         clientRequest.setState("SP");
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
 
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("accountRegistered", accountRegistered);
-        responseMap.put("balanceMoney", accountRequest.getBalanceMoney());
-
-        String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/accounts/12345678901")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isCreated());
     }
 
@@ -98,19 +89,18 @@ public class AccountControllerTests {
         clientRequest.setPostalCode("02036020");
         clientRequest.setState("SP");
 
+        AccountRequest accountRequest = new AccountRequest();
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
-        /*Não criar o balance money*/
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
 
-        String requestBody = new ObjectMapper().valueToTree(accountRegistered).toString();
         clientService.registerClient(clientRequest);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/accounts/12345678901")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+        mockMvc.perform(MockMvcRequestBuilders.post("/accounsts/12345678901")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }
 
@@ -124,26 +114,20 @@ public class AccountControllerTests {
         clientRequest.setPostalCode("02036020");
         clientRequest.setState("SP");
 
+
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
 
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("accountRegistered", accountRegistered);
-        responseMap.put("balanceMoney", accountRequest.getBalanceMoney());
-
-        String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
         accountService.deleteAccount(account.getId());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/accounts/delete/1")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isAccepted());
     }
     @Test
@@ -157,25 +141,20 @@ public class AccountControllerTests {
         clientRequest.setState("SP");
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
 
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("accountRegistered", accountRegistered);
-        responseMap.put("balanceMoney", accountRequest.getBalanceMoney());
+        clientService.registerClient(clientRequest);
 
-        String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
         accountService.deleteAccount(account.getId());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/accounts/delete")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }
 }

--- a/src/test/java/BankApplication/client/ControllerTests/ClientControllerTests.java
+++ b/src/test/java/BankApplication/client/ControllerTests/ClientControllerTests.java
@@ -1,8 +1,8 @@
 package BankApplication.client.ControllerTests;
 
-import BankApplication.client.controller.ClientController;
-import BankApplication.client.request.ClientRequest;
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.controller.ClientController;
+import BankApplication.account.controller.client.request.ClientRequest;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/BankApplication/client/ServiceTests/ClientServiceTests.java
+++ b/src/test/java/BankApplication/client/ServiceTests/ClientServiceTests.java
@@ -1,10 +1,10 @@
 package BankApplication.client.ServiceTests;
 
-import BankApplication.client.exceptions.CpfAlreadyExistsException;
+import BankApplication.account.controller.client.exceptions.CpfAlreadyExistsException;
 import BankApplication.model.Client;
-import BankApplication.client.repository.ClientRepository;
-import BankApplication.client.request.ClientRequest;
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.repository.ClientRepository;
+import BankApplication.account.controller.client.request.ClientRequest;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/BankApplication/transactions/ControllerTests/TransactionControllerTests.java
+++ b/src/test/java/BankApplication/transactions/ControllerTests/TransactionControllerTests.java
@@ -3,9 +3,9 @@ package BankApplication.transactions.ControllerTests;
 import BankApplication.account.repository.AccountRepository;
 import BankApplication.account.request.AccountRequest;
 import BankApplication.account.service.AccountServiceImpl;
-import BankApplication.client.repository.ClientRepository;
-import BankApplication.client.request.ClientRequest;
-import BankApplication.client.service.ClientServiceImpl;
+import BankApplication.account.controller.client.repository.ClientRepository;
+import BankApplication.account.controller.client.request.ClientRequest;
+import BankApplication.account.controller.client.service.ClientServiceImpl;
 import BankApplication.model.Account;
 import BankApplication.model.Transaction;
 import BankApplication.transaction.controller.TransactionController;
@@ -88,13 +88,13 @@ public class TransactionControllerTests {
         clientRequest.clientObjectRequest().setId(1L);
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
+        Account accountRegistered = accountService.registerAccount(clientRequest.getCpf());
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accountRegistered", accountRegistered);
@@ -102,7 +102,7 @@ public class TransactionControllerTests {
 
         String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Long clientId = clientRequest.clientObjectRequest().getId();
 
@@ -129,13 +129,13 @@ public class TransactionControllerTests {
         clientRequest.clientObjectRequest().setId(1L);
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
+        Account accountRegistered = accountService.registerAccount(clientRequest.getCpf());
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accountRegistered", accountRegistered);
@@ -143,7 +143,7 @@ public class TransactionControllerTests {
 
         String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Long clientId = clientRequest.clientObjectRequest().getId();
 
@@ -177,7 +177,7 @@ public class TransactionControllerTests {
         account.setClient(clientRequest.clientObjectRequest());
 
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Transaction transactionRequest = new Transaction();
         transactionRequest.setAccount(account);
@@ -206,14 +206,15 @@ public class TransactionControllerTests {
         clientRequest.clientObjectRequest().setId(1L);
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
+        account.setBalanceMoney(balanceMoney);
 
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Transaction transactionRequest = new Transaction();
         transactionRequest.setAccount(account);
@@ -242,13 +243,13 @@ public class TransactionControllerTests {
         clientRequest.clientObjectRequest().setId(1L);
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
+        Account accountRegistered = accountService.registerAccount(clientRequest.getCpf());
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accountRegistered", accountRegistered);
@@ -256,7 +257,7 @@ public class TransactionControllerTests {
 
         String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Transaction transactionRequest = new Transaction();
         transactionRequest.setAccount(account);
@@ -286,13 +287,13 @@ public class TransactionControllerTests {
         clientRequest.clientObjectRequest().setId(1L);
 
         AccountRequest accountRequest = new AccountRequest();
-        accountRequest.setBalanceMoney(BigDecimal.valueOf(Long.parseLong("0")));
+        BigDecimal balanceMoney = accountRequest.getBalanceMoney();
 
         Account account = new Account();
         account.setAccountNumber(accountRepository.generateAccountNumber());
         account.setClient(clientRequest.clientObjectRequest());
-        account.setBalanceMoney(accountRequest.getBalanceMoney());
-        Account accountRegistered = accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        account.setBalanceMoney(balanceMoney);
+        Account accountRegistered = accountService.registerAccount(clientRequest.getCpf());
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accountRegistered", accountRegistered);
@@ -300,7 +301,7 @@ public class TransactionControllerTests {
 
         String requestBody = new ObjectMapper().writeValueAsString(responseMap);
         clientService.registerClient(clientRequest);
-        accountService.registerAccount(accountRequest, clientRequest.getCpf());
+        accountService.registerAccount(clientRequest.getCpf());
 
         Transaction transactionRequest = new Transaction();
         transactionRequest.setAccount(account);


### PR DESCRIPTION
… útil quando você não quer incluir todas as propriedades de uma classe na resposta JSON, mas pode levar a problemas se precisar retornar diferentes formatos de resposta ou adicionar/remover propriedades no futuro. Desta forma, não criei o DTO.